### PR TITLE
make icc-rt a dependency only for Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ matplotlib = "^3.2.2"
 numba = ">=0.52"
 numpy = ">=1.18, <1.23"
 pathlib = "^1.0.1"
-icc-rt = "^2020.0.133"
+icc-rt = {version = "^2020.0.133", platform = "linux"}
 Bottleneck = "^1.3.2"
 psutil = "^5.9.0"
 


### PR DESCRIPTION
It would cause fail in `poetry add` on macOS and Windows that `icc-rt@^2020.0.133` not supported.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/N720720/lindemann/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/N720720/lindemann/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
